### PR TITLE
Turns out some tar archives don't contain dirs

### DIFF
--- a/lib/mixlib/archive/tar.rb
+++ b/lib/mixlib/archive/tar.rb
@@ -24,6 +24,8 @@ module Mixlib
               next
             end
             dest ||= File.join(destination, entry.full_name)
+            parent = File.dirname(dest)
+            FileUtils.mkdir_p(parent, mode: 0755)
 
             if entry.directory? || (entry.header.typeflag == "" && entry.full_name.end_with?("/"))
               File.delete(dest) if File.file?(dest)


### PR DESCRIPTION
So we'll create the parent automatically, and we'll make it 0755 because
that's the only sane thing we can do.

Signed-off-by: Thom May <thom@may.lt>