### PR TITLE
Ignore directory traversing file_names in an tar

### DIFF
--- a/lib/mixlib/archive.rb
+++ b/lib/mixlib/archive.rb
@@ -26,6 +26,8 @@ module Mixlib
     end
 
     def extract(destination, perms: true, ignore: [])
+      ignore = [/^\.$/, /\.{2}/] + ignore
+
       create_and_empty(destination)
 
       archiver.extract(destination, perms: perms, ignore: ignore)

--- a/lib/mixlib/archive/tar.rb
+++ b/lib/mixlib/archive/tar.rb
@@ -29,7 +29,10 @@ module Mixlib
               dest = File.join(destination, entry.read.strip)
               next
             end
-            next if entry.full_name =~ ignore_re
+            if entry.full_name =~ ignore_re
+              Mixlib::Archive::Log.warn "ignoring entry #{entry.full_name}"
+              next
+            end
             dest ||= File.join(destination, entry.full_name)
             parent = File.dirname(dest)
             FileUtils.mkdir_p(parent)

--- a/spec/mixlib/archive_spec.rb
+++ b/spec/mixlib/archive_spec.rb
@@ -21,6 +21,7 @@ describe Mixlib::Archive do
     it "accepts a path" do
       expect { described_class.new("../foo") }.not_to raise_error
     end
+
     it "allows the target to be emptied" do
       expect { described_class.new("../foo", empty: true) }.not_to raise_error
     end
@@ -57,13 +58,18 @@ describe Mixlib::Archive do
     end
 
     it "runs the extractor" do
-      expect(archiver).to receive(:extract).with(destination, { perms: true, ignore: [] })
+      expect(archiver).to receive(:extract).with(destination, { perms: true, ignore: [/^\.$/, /\.{2}/] })
       archive.extract(destination)
     end
 
     it "passes options to the extractor" do
-      expect(archiver).to receive(:extract).with(destination, { perms: false, ignore: [] })
+      expect(archiver).to receive(:extract).with(destination, { perms: false, ignore: [/^\.$/, /\.{2}/] })
       archive.extract(destination, perms: false)
+    end
+
+    it "allows the user to ignore more patterns" do
+      expect(archiver).to receive(:extract).with(destination, { perms: false, ignore: [/^\.$/, /\.{2}/, /^$/] })
+      archive.extract(destination, perms: false, ignore: [/^$/])
     end
   end
 


### PR DESCRIPTION
It's possible to construct tar archives with entries that contain path
names that traverse outside the target directory. We will now just
ignore those entries

Signed-off-by: Thom May <thom@chef.io>