### PR TITLE
Fix read_tar_magic to properly return an array when a file has less than 264 characters

### DIFF
--- a/lib/mixlib/archive/tar.rb
+++ b/lib/mixlib/archive/tar.rb
@@ -125,7 +125,7 @@ module Mixlib
 
       def read_tar_magic(io)
         io.rewind
-        magic = io.read(512).bytes[257..264].pack("C*")
+        magic = Array(io.read(512).bytes[257..264]).pack("C*")
         io.rewind
         magic
       end

--- a/spec/mixlib/tar_spec.rb
+++ b/spec/mixlib/tar_spec.rb
@@ -98,6 +98,13 @@ describe Mixlib::Archive::Tar do
         expect(extractor.send(:is_tar_archive?, raw)).to eq(false)
       end
     end
+    context "invalid small file" do
+      let(:data) { "testdir/#{Array.new(11) { "\x00" }.join}smallfile" }
+      it "does not identify an invalid header in a small file" do
+        extractor = described_class.new(tgz_archive)
+        expect(extractor.send(:is_tar_archive?, raw)).to eq(false)
+      end
+    end
   end
 
 end


### PR DESCRIPTION
### Description

In the case that a file is smaller than 264 characters, nil is returned rather than an array, alas the pack method is not available.

This is what is causing the AppVeyor build failure on ChefDK.

```
undefined method `pack' for nil:NilClass
```


### Issues Resolved

Hopefully this allows us to bump `mixlib-archive` to address https://github.com/chef/chef-dk/issues/1663 via https://github.com/chef/chef-dk/pull/1664

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
