### PR TITLE
Add a mingw32 specific gemspec to limit files shipped on *nix

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,5 @@
 # Order is important. The last matching pattern has the most precedence.
 
-*               @chef/client-maintainers
-.expeditor/**   @chef/jex-team
+*                 @chef/client-maintainers
+.expeditor/**     @chef/jex-team
+README.md         @chef/docs-team

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gemspec
+gemspec name: "mixlib-archive"
 
 gem "ffi-libarchive"
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,9 @@
-require "bundler/gem_tasks"
+require "bundler"
 require "rspec/core/rake_task"
 
-task default: [:style, :spec]
+Bundler::GemHelper.install_tasks name: "mixlib-archive"
 
-Bundler::GemHelper.install_tasks
+task default: [:style, :spec]
 
 desc "Run specs"
 RSpec::Core::RakeTask.new(:spec) do |spec|

--- a/mixlib-archive-universal-mingw32.gemspec
+++ b/mixlib-archive-universal-mingw32.gemspec
@@ -1,4 +1,4 @@
-gemspec = eval(IO.read(File.expand_path("../mixlib-archive.gemspec", __FILE__)))
+gemspec = eval(IO.read(File.expand_path("../mixlib-archive.gemspec", __FILE__))) # rubocop: disable Security/Eval
 
 gemspec.platform = Gem::Platform.new(%w{universal mingw32})
 

--- a/mixlib-archive-universal-mingw32.gemspec
+++ b/mixlib-archive-universal-mingw32.gemspec
@@ -1,0 +1,7 @@
+gemspec = eval(IO.read(File.expand_path("../mixlib-archive.gemspec", __FILE__)))
+
+gemspec.platform = Gem::Platform.new(%w{universal mingw32})
+
+gemspec.files += Dir.glob("{distro}/**/*")
+
+gemspec

--- a/mixlib-archive.gemspec
+++ b/mixlib-archive.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/chef/mixlib-archive"
   spec.license       = "Apache-2.0"
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = %w{LICENSE README.md} + Dir.glob("lib/**/*")
   spec.require_paths = ["lib"]
 
   spec.add_dependency "mixlib-log"


### PR DESCRIPTION
This drops our on disk size by over 4 megs. We're also limiting what files we include on all systems to skip travis, appveyor, gemfile, and other dev files.

Signed-off-by: Tim Smith <tsmith@chef.io>