### PR TITLE
Optimize requires for non-omnibus installs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :docs do
 end
 
 group :test do
-  gem "chefstyle"
+  gem "chefstyle", "1.2.1"
   gem "rake"
   gem "rspec", "~> 3.0"
 end
@@ -19,7 +19,7 @@ end
 group :debug do
   gem "pry"
   gem "pry-byebug"
-  gem "pry-stack_explorer"
+  gem "pry-stack_explorer", "~> 0.4.0" # pin until we drop ruby < 2.6
   gem "rb-readline"
 end
 

--- a/lib/mixlib/archive/tar.rb
+++ b/lib/mixlib/archive/tar.rb
@@ -1,5 +1,5 @@
 require "rubygems/package"
-require "tempfile"
+require "tempfile" unless defined?(Tempfile)
 require "zlib"
 
 module Mixlib

--- a/mixlib-archive.gemspec
+++ b/mixlib-archive.gemspec
@@ -1,4 +1,3 @@
-# coding: utf-8
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "mixlib/archive/version"


### PR DESCRIPTION
require is quite slow in Ruby and doing requires for things you've already required is also slow. We've used this simple hack in Chef to speed up our requires. In the omnibus installs we patch how rubygems works to make this somewhat pointless, but this will help non-omnibus installs

Signed-off-by: Tim Smith <tsmith@chef.io>