### PR TITLE
Optimize our requires

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -26,7 +26,7 @@ rescue LoadError
 end
 
 begin
-  require "yard"
+  require "yard" unless defined?(YARD)
   YARD::Rake::YardocTask.new(:docs)
 rescue LoadError
   puts "yard is not available. bundle install first to make sure all dependencies are installed."
@@ -35,7 +35,7 @@ end
 task :console do
   require "irb"
   require "irb/completion"
-  require "mixlib/archive"
+  require "mixlib/archive" unless defined?(Mixlib::Archive)
   ARGV.clear
   IRB.start
 end

--- a/lib/mixlib/archive.rb
+++ b/lib/mixlib/archive.rb
@@ -1,7 +1,7 @@
 require_relative "archive/tar"
 require_relative "archive/version"
 require "mixlib/log"
-require "find"
+require "find" unless defined?(Find.find)
 
 module Mixlib
   class Archive

--- a/lib/mixlib/archive/tar.rb
+++ b/lib/mixlib/archive/tar.rb
@@ -1,6 +1,6 @@
-require "rubygems/package"
+require "rubygems/package" unless defined?(Gem::Package)
 require "tempfile" unless defined?(Tempfile)
-require "zlib"
+require "zlib" unless defined?(Zlib)
 
 module Mixlib
   class Archive


### PR DESCRIPTION
Avoid requiring things that are already defined. Rubygems is very slow at traversing the filesystem.

Signed-off-by: Tim Smith <tsmith@chef.io>