### PR TITLE
Remove Dir.chdir calls from libarchive extraction

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,8 @@ source "https://rubygems.org"
 
 gemspec name: "mixlib-archive"
 
-gem "ffi-libarchive"
+# need the extract=to-destination support in ffi-libarchive 1.0.17
+gem "ffi-libarchive", ">= 1.0.17"
 
 group :docs do
   gem "github-markup"


### PR DESCRIPTION
Uses new API extension in ffi-libarchive 1.0.17 to extract directly
to a destination without using Dir.chdir.

Since mixlib-archive doesn't take a direct dep on ffi-libarchive this
might break people that somehow manage to upgrade mixlib-archive without
upgrading that one.  Without a dep there is no way to specify a
constraint though.  The lack of a dep is a design feature of this
gem though so that people can just use tar and not have to use
libarchive.

This is required for Ruby 3.0 where the jankiness around the Dir.chdir
mutex is no longer sufficient if we're called already from within a
Dir.chdir on a different Thread (it may be properly nested so that
the other Thread never exits the Dir.chdir until we complete, but
there's no way to synchronize that and ruby-3.0 now fails hard).
