### PR TITLE
Remove the pry-stack_explorer dep failing Ruby 2.4 builds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,6 @@ end
 group :debug do
   gem "pry"
   gem "pry-byebug"
-  gem "pry-stack_explorer", "~> 0.4.0" # pin until we drop ruby < 2.6
   gem "rb-readline"
 end
 


### PR DESCRIPTION
This dep causes tons of pain with ruby releases it drops support for.
Just nuke it.

Signed-off-by: Tim Smith <tsmith@chef.io>