### PR TITLE
Convert destination to a String

### DIFF
--- a/lib/mixlib/archive/lib_archive.rb
+++ b/lib/mixlib/archive/lib_archive.rb
@@ -29,7 +29,7 @@ module Mixlib
             next
           end
 
-          reader.extract(entry, flags.to_i, destination: destination)
+          reader.extract(entry, flags.to_i, destination: destination.to_s)
         end
         reader.close
       end


### PR DESCRIPTION
berkshelf and other upstreams can give us Pathname objects.
