### PR TITLE
Remove Ruby 2.4 support & Test Ruby 3.0/3.1

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -19,7 +19,7 @@ steps:
   expeditor:
     executor:
       docker:
-        image: ruby:2.4-buster
+        image: ruby:2.4
 
 - label: run-lint-and-specs-ruby-2.5
   command:
@@ -29,7 +29,7 @@ steps:
   expeditor:
     executor:
       docker:
-        image: ruby:2.5-buster
+        image: ruby:2.5
 
 - label: run-lint-and-specs-ruby-2.6
   command:
@@ -39,7 +39,7 @@ steps:
   expeditor:
     executor:
       docker:
-        image: ruby:2.6-buster
+        image: ruby:2.6
 
 - label: run-lint-and-specs-ruby-2.7
   command:
@@ -49,7 +49,7 @@ steps:
   expeditor:
     executor:
       docker:
-        image: ruby:2.7-buster
+        image: ruby:2.7
 
 - label: run-lint-and-specs-ruby-3.0
   command:
@@ -59,7 +59,17 @@ steps:
   expeditor:
     executor:
       docker:
-        image: ruby:2.7-buster
+        image: ruby:3.0
+
+- label: run-lint-and-specs-ruby-3.1
+  command:
+    - apt-get update
+    - apt-get install -y libarchive-dev
+    - .expeditor/run_linux_tests.sh rake
+  expeditor:
+    executor:
+      docker:
+        image: ruby:3.1
 
 - label: run-specs-windows
   command:

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -11,16 +11,6 @@ expeditor:
 
 steps:
 
-- label: run-lint-and-specs-ruby-2.4
-  command:
-    - apt-get update
-    - apt-get install -y libarchive-dev
-    - .expeditor/run_linux_tests.sh rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.4
-
 - label: run-lint-and-specs-ruby-2.5
   command:
     - apt-get update

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Order is important. The last matching pattern has the most precedence.
 
 *                 @chef/chef-foundation-owners @chef/chef-foundation-approvers @chef/chef-foundation-reviewers
-.expeditor/       @chef/jex-team
+.expeditor/       @chef/infra-packages
 *.md              @chef/docs-team

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ group :test do
   gem "chefstyle", "1.6.2"
   gem "rake"
   gem "rspec", "~> 3.0"
+  gem "parallel", "~> 1.20.1" #pin until we support ruby 2.4
 end
 
 group :debug do

--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,9 @@ gem "ffi-libarchive", ">= 1.0.17"
 
 group :test do
   gem "chefstyle", "1.6.2"
+  gem "parallel", "~> 1.20.1" # pin until we support ruby 2.4
   gem "rake"
   gem "rspec", "~> 3.0"
-  gem "parallel", "~> 1.20.1" #pin until we support ruby 2.4
 end
 
 group :debug do

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ gem "ffi-libarchive", ">= 1.0.17"
 
 group :test do
   gem "chefstyle", "1.6.2"
-  gem "parallel", "~> 1.20.1" # pin until we support ruby 2.4
   gem "rake"
   gem "rspec", "~> 3.0"
 end

--- a/mixlib-archive.gemspec
+++ b/mixlib-archive.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = spec.summary
   spec.homepage      = "https://github.com/chef/mixlib-archive"
   spec.license       = "Apache-2.0"
-  spec.required_ruby_version = ">= 2.4"
+  spec.required_ruby_version = ">= 2.5"
 
   spec.files         = %w{LICENSE} + Dir.glob("lib/**/*")
   spec.require_paths = ["lib"]


### PR DESCRIPTION
Signed-off-by: poornima <poorndm@progress.com>
Test Ruby 3.0 /3.1. A very simple gem to create and extract archives.
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
