### PR TITLE
starting to integrate ruby 3.1 into the builds

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -11,26 +11,6 @@ expeditor:
 
 steps:
 
-- label: run-lint-and-specs-ruby-2.5
-  command:
-    - apt-get update
-    - apt-get install -y libarchive-dev
-    - .expeditor/run_linux_tests.sh rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.5
-
-- label: run-lint-and-specs-ruby-2.6
-  command:
-    - apt-get update
-    - apt-get install -y libarchive-dev
-    - .expeditor/run_linux_tests.sh rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.6
-
 - label: run-lint-and-specs-ruby-2.7
   command:
     - apt-get update

--- a/mixlib-archive-universal-ucrt.gemspec
+++ b/mixlib-archive-universal-ucrt.gemspec
@@ -1,0 +1,7 @@
+gemspec = eval(IO.read(File.expand_path("mixlib-archive.gemspec", __dir__))) # rubocop: disable Security/Eval
+
+gemspec.platform = Gem::Platform.new(%w{x64-mingw-ucrt})
+
+gemspec.files += Dir.glob("{distro}/**/*")
+
+gemspec


### PR DESCRIPTION
Signed-off-by: John McCrae <john.mccrae@progress.com>

Updating dependencies for Chef-18. 

## Description
This file is needed to add support for Ruby 3.1

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
