### PR TITLE
add myself to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Order is important. The last matching pattern has the most precedence.
 
-*                 @chef/chef-foundation-owners @chef/chef-foundation-approvers @chef/chef-foundation-reviewers
+*                 @chef/chef-foundation-owners @chef/chef-foundation-approvers @chef/chef-foundation-reviewers @jaymzh
 .expeditor/       @chef/infra-packages
 *.md              @chef/docs-team


### PR DESCRIPTION
Adding myself to code-owners until Progress can figure out what is going on with access via groups for external contributors, which they nuked

Signed-off-by: Phil Dibowitz <phil@ipom.com>
