### PR TITLE
Updating for Ruby 3.4 and Cookstyle

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -11,16 +11,6 @@ expeditor:
 
 steps:
 
-- label: run-lint-and-specs-ruby-3.0
-  command:
-    - apt-get update
-    - apt-get install -y libarchive-dev
-    - .expeditor/run_linux_tests.sh rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:3.0
-
 - label: run-lint-and-specs-ruby-3.1
   command:
     - apt-get update
@@ -31,16 +21,15 @@ steps:
       docker:
         image: ruby:3.1
 
-- label: run-specs-ruby-3.0-windows
+- label: run-lint-and-specs-ruby-3.4
   command:
-    - .expeditor/run_windows_tests.ps1
+    - apt-get update
+    - apt-get install -y libarchive-dev
+    - .expeditor/run_linux_tests.sh rake
   expeditor:
     executor:
       docker:
-        host_os: windows
-        shell: ["powershell", "-Command"]
-        image: rubydistros/windows-2019:3.0
-        user: 'NT AUTHORITY\SYSTEM'
+        image: ruby:3.4
 
 - label: run-specs-ruby-3.1-windows
   command:
@@ -51,4 +40,15 @@ steps:
         host_os: windows
         shell: ["powershell", "-Command"]
         image: rubydistros/windows-2019:3.1
+        user: 'NT AUTHORITY\SYSTEM'
+
+- label: run-specs-ruby-3.4-windows
+  command:
+    - .expeditor/run_windows_tests.ps1
+  expeditor:
+    executor:
+      docker:
+        host_os: windows
+        shell: ["powershell", "-Command"]
+        image: rubydistros/windows-2019:3.4
         user: 'NT AUTHORITY\SYSTEM'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+- package-ecosystem: bundler
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "06:00"
+    timezone: America/Los_Angeles
+  open-pull-requests-limit: 10

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,27 @@
+---
+name: lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.1
+          bundler-cache: false
+      - uses: r7kamura/rubocop-problem-matchers-action@v1  # this shows the failures in the PR
+      - run: |
+          gem install cookstyle
+          cookstyle --chefstyle -c .rubocop.yml
+  

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,0 +1,31 @@
+---
+name: unit
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-2019, windows-2022]
+        ruby: ['3.1', '3.4']
+    name: Unit test on ${{ matrix.os }} with Ruby ${{ matrix.ruby }}
+    runs-on: ${{ matrix.os }}
+    env:
+      RUBYOPT: '--disable-error_highlight'
+    steps:
+      - uses: actions/checkout@v4
+      - name: ruby-setup
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: bundle exec rake spec

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,48 @@
+AllCops:
+  TargetRubyVersion: 2.6
+  Exclude:
+    - "spec/data/**/*"
+    - "habitat/**/*"
+    - "vendor/**/*"
+Security/Eval:
+  Enabled: false
+Lint/UselessAssignment:
+  Enabled: false
+Lint/DeprecatedClassMethods:
+  Enabled: false
+Lint/AmbiguousRegexpLiteral:
+  Enabled: false
+Lint/AssignmentInCondition:
+  Enabled: false
+Lint/AmbiguousBlockAssociation:
+  Enabled: false
+Layout/EndOfLine:
+   Enabled: false
+Lint/ShadowingOuterLocalVariable:
+  Enabled: false
+Lint/IneffectiveAccessModifier:
+  Enabled: false
+Lint/InterpolationCheck:
+  Enabled: true
+  Exclude:
+    - 'spec/unit/property_spec.rb'
+    - 'spec/functional/shell_spec.rb'
+Lint/DeprecatedConstants:
+  Enabled: true
+  Exclude:
+    - lib/chef/node/attribute.rb # false alarms
+
+
+# This cop shouldn't alert on the helper / specs itself
+Chef/Ruby/LegacyPowershellOutMethods:
+  Exclude:
+    - 'lib/chef/mixin/powershell_out.rb'
+    - 'spec/functional/mixin/powershell_out_spec.rb'
+    - 'spec/unit/mixin/powershell_out_spec.rb'
+    - 'lib/chef/resource/windows_feature_powershell.rb' # https://github.com/chef/chef/issues/10927
+    - 'lib/chef/provider/package/powershell.rb' # https://github.com/chef/chef/issues/10926
+
+# set additional paths
+Chef/Ruby/UnlessDefinedRequire:
+  Include:
+    - 'lib/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ gemspec name: "mixlib-archive"
 gem "ffi-libarchive", ">= 1.0.17"
 
 group :test do
-  gem "cookstyle", ">= 7.32.8"
   gem "rake"
   gem "rspec", "~> 3.0"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -14,15 +14,20 @@ rescue LoadError
   end
 end
 
-begin
-  require "cookstyle/chefstyle"
+desc "Check Linting and code style."
+task :style do
   require "rubocop/rake_task"
-  desc "Run Chefstyle tests"
-  RuboCop::RakeTask.new(:style) do |task|
-    task.options += ["--display-cop-names", "--no-color"]
+  require "cookstyle/chefstyle"
+
+  if RbConfig::CONFIG["host_os"] =~ /mswin|mingw|cygwin/
+    # Windows-specific command, rubocop erroneously reports the CRLF in each file which is removed when your PR is uploaeded to GitHub.
+    # This is a workaround to ignore the CRLF from the files before running cookstyle.
+    sh "cookstyle --chefstyle -c .rubocop.yml --except Layout/EndOfLine"
+  else
+    sh "cookstyle --chefstyle -c .rubocop.yml"
   end
 rescue LoadError
-  puts "cookstyle gem is not installed. bundle install first to make sure all dependencies are installed."
+  puts "Rubocop or Cookstyle gems are not installed. bundle install first to make sure all dependencies are installed."
 end
 
 task :console do

--- a/mixlib-archive-universal-mingw-ucrt.gemspec
+++ b/mixlib-archive-universal-mingw-ucrt.gemspec
@@ -1,6 +1,6 @@
 gemspec = eval(IO.read(File.expand_path("mixlib-archive.gemspec", __dir__))) # rubocop: disable Security/Eval
 
-gemspec.platform = Gem::Platform.new(%w{universal mingw32})
+gemspec.platform = Gem::Platform.new(%w{universal mingw-ucrt})
 
 gemspec.files += Dir.glob("{distro}/**/*")
 

--- a/mixlib-archive.gemspec
+++ b/mixlib-archive.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "mixlib-log"
+  spec.add_development_dependency "cookstyle", "~> 8.1"
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Chef-19 is moving to Ruby 3.4 and Cookstyle. Here we update the code to reflect these changes but stay compatible with Chef-18

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
